### PR TITLE
Move 'version.cr' source files to the correct locations

### DIFF
--- a/src/i3/message/version.cr
+++ b/src/i3/message/version.cr
@@ -1,0 +1,18 @@
+require "json"
+
+module I3
+  # Represents the response to a `Message::MessageType::GET_VERSION` request.
+  #
+  # See `Connection#version`.
+  class Message
+    class Version
+      JSON.mapping(
+        major: Int32,
+        minor: Int32,
+        patch: Int32,
+        human_readable: String,
+        loaded_config_file_name: String,
+      )
+    end
+  end
+end

--- a/src/i3/version.cr
+++ b/src/i3/version.cr
@@ -1,18 +1,4 @@
-require "json"
-
 module I3
-  # Represents the response to a `Message::MessageType::GET_VERSION` request.
-  #
-  # See `Connection#version`.
-  class Message
-    class Version
-      JSON.mapping(
-        major: Int32,
-        minor: Int32,
-        patch: Int32,
-        human_readable: String,
-        loaded_config_file_name: String,
-      )
-    end
-  end
+  # The current version of `i3.cr`.
+  VERSION = "0.3.0"
 end

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,4 +1,0 @@
-module I3
-  # The current version of `i3.cr`.
-  VERSION = "0.3.0"
-end


### PR DESCRIPTION
As-is, using `require "version"` would require the library's version file, which is polluting the global require path